### PR TITLE
Keep case format from original word

### DIFF
--- a/admin/includes/cmb2-extra.php
+++ b/admin/includes/cmb2-extra.php
@@ -24,6 +24,12 @@ function ds_cmb_render_multicheck_posttype( $field, $escaped_value, $object_id, 
 			if ( in_array( $cpt, $values ) ) {
 				$args[ 'checked' ] = 'checked';
 			}
+
+			// @TODO Possibly find a solution if CMB2 trunk commit 1b3e251f8db429b3930e44ff43495838a9a39744
+			// is merged in to master, as this will no longer work becasue the function
+			// list_input is moved to another class.
+			//
+			// https://github.com/WebDevStudios/CMB2/commit/1b3e251f8db429b3930e44ff43495838a9a39744#diff-32fc356ab519c81b4a672288be3a1e46
 			$options .= $field_type_object->list_input( $args, $i );
 			$i++;
 		}

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -257,16 +257,16 @@ class Glossary {
           global $post;
           $links[] = $this->tooltip_html( $link, '$0', $post, $target, $nofollow, $internal );
         } else {
-          $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>' . get_the_title() . '</a>';
+          $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>$0</a>';
         }
         $related = $this->related_post_meta( get_post_meta( get_the_ID(), $this->get_plugin_slug() . '_tag', true ) );
         if ( is_array( $related ) ) {
           foreach ( $related as $value ) {
             $words[] = $this->search_string( $value );
             if ( isset( $this->settings[ 'tooltip' ] ) ) {
-              $links[] = $this->tooltip_html( $link, $value, $post, $target, $nofollow, $internal );
+              $links[] = $this->tooltip_html( $link, '$0', $post, $target, $nofollow, $internal );
             } else {
-              $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>' . $value . '</a>';
+              $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>$0</a>';
             }
           }
         }

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -255,7 +255,7 @@ class Glossary {
         $words[] = $this->search_string( get_the_title() );
         if ( isset( $this->settings[ 'tooltip' ] ) ) {
           global $post;
-          $links[] = $this->tooltip_html( $link, get_the_title(), $post, $target, $nofollow, $internal );
+          $links[] = $this->tooltip_html( $link, "$0", $post, $target, $nofollow, $internal );
         } else {
           $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>' . get_the_title() . '</a>';
         }

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -255,7 +255,7 @@ class Glossary {
         $words[] = $this->search_string( get_the_title() );
         if ( isset( $this->settings[ 'tooltip' ] ) ) {
           global $post;
-          $links[] = $this->tooltip_html( $link, "$0", $post, $target, $nofollow, $internal );
+          $links[] = $this->tooltip_html( $link, '$0', $post, $target, $nofollow, $internal );
         } else {
           $links[] = '<a href="' . $link . '"' . $target . $nofollow . '>' . get_the_title() . '</a>';
         }


### PR DESCRIPTION
Use the original word from the text instead of the word from the glossary title or related words. This prevents wrongly formatted words, with capital letters in the middle of the text. 
