### PR TITLE
Introduce Singleton Pattern to Tooltip Engine Classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+
+php:
+    - 5.5
+    - 5.6
+    - 7.0
+
+env:
+    - WP_VERSION=4.6 WP_MULTISITE=0
+    - WP_VERSION=4.6 WP_MULTISITE=1
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=1
+
+matrix:
+    include:
+        - php: 5.3
+          env: WP_VERSION=4.1.11 WP_MULTISITE=1
+
+
+before_script:
+    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+
+script: phpunit
+
+

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/public/includes/Glossary_Tooltip_Engine.php
+++ b/public/includes/Glossary_Tooltip_Engine.php
@@ -11,6 +11,31 @@
  * @copyright 2015 GPL
  */
 class Glossary_Tooltip_Engine {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @since 1.3.0
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Glossary_Tooltip_Engine.
+	 *
+	 * Ensure only one instance of Glossary_Tooltip_Engine is loaded.
+	 *
+	 * @static
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Glossary_Tooltip_Engine - Main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
 
   /**
    * Initialize the class with all the hooks
@@ -272,4 +297,17 @@ class Glossary_Tooltip_Engine {
 
 }
 
-new Glossary_Tooltip_Engine();
+/**
+ * Main instance of Glossary_Tooltip_Engine.
+ *
+ * Returns the main instance of Glossary_Tooltip_Engine to prevent the need to use globals.
+ *
+ * @since 1.3.0
+ *
+ * @return Glossary_Tooltip_Engine
+ */
+function Glossary_Tooltip_Engine() {
+	return Glossary_Tooltip_Engine::get_instance();
+}
+
+Glossary_Tooltip_Engine();

--- a/public/includes/Glossary_a2z_Archive.php
+++ b/public/includes/Glossary_a2z_Archive.php
@@ -12,6 +12,32 @@
  */
 class Glossary_a2z_Archive {
 
+	/**
+	 * The single instance of the class.
+	 *
+	 * @since 1.3.0
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Glossary_a2z_Archive.
+	 *
+	 * Ensure only one instance of Glossary_a2z_Archive is loaded.
+	 *
+	 * @static
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Glossary_a2z_Archive - Main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
   /**
    * Initialize the plugin by setting localization and loading public scripts
    * and styles.
@@ -25,7 +51,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Add our value
-   * 
+   *
    * @param array $query_vars
    * @return array
    */
@@ -36,7 +62,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Check our value
-   * 
+   *
    * @global object $wp_query
    * @param object $query
    */
@@ -50,7 +76,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Alter the SQL
-   * 
+   *
    * @global object $wp_query
    * @global object $wpdb
    * @param string $where
@@ -65,7 +91,7 @@ class Glossary_a2z_Archive {
 
   /**
    * Alter the SQL
-   * 
+   *
    * @global object $wpdb
    * @param string $orderby
    * @return string
@@ -80,4 +106,17 @@ class Glossary_a2z_Archive {
 
 }
 
-new Glossary_a2z_Archive();
+/**
+ * Main instance of Glossary_a2z_Archive.
+ *
+ * Returns the main instance of Glossary_a2z_Archive to prevent the need to use globals.
+ *
+ * @since 1.3.0
+ *
+ * @return Glossary_a2z_Archive
+ */
+function Glossary_a2z_Archive() {
+	return Glossary_a2z_Archive::get_instance();
+}
+
+Glossary_a2z_Archive();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __FILE__ ) . '/../glossary.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+

--- a/tests/test-glossary.php
+++ b/tests/test-glossary.php
@@ -1,0 +1,120 @@
+<?php
+
+class GlossaryTest extends WP_UnitTestCase {
+
+	public $plugin;
+
+	function setUp() {
+
+		parent::setUp();
+
+		// Setup plugin options so that tooltips are enabled.
+		$option_values = array(
+			'posttypes'		=> array( 'post', 'page' ),
+			'tooltip_style'	=> 'box',
+			'excerpt_limit'	=> '60',
+			'slug'			=> 'glossary',
+			'slug-cat'		=> 'glossary-cat',
+			'tooltip'		=> 'on',
+		);
+		add_option( 'glossary-settings', $option_values );
+	}
+
+
+	function testGlossaryAutoLink() {
+		// Setup original body and expected output.
+		$body = 'Post content contains the word philosophy which should have a definition.';
+		$body_tooltip_box = 'Post content contains the word <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=philosophy">philosophy</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">From the latin for love of wisdom.</span></span></span> which should have a definition.';
+
+		// Create glossary term.
+		$glossary_post_arr = array(
+				'post_title' 	=> 'Philosophy',
+				'post_content'	=> 'From the latin for love of wisdom.',
+				'post_type'		=> 'glossary',
+				'post_status'	=> 'publish',
+		);
+		$glossary_post_id = wp_insert_post( $glossary_post_arr );
+		add_post_meta( $glossary_post_id, 'glossary_link_type', 'internal' );
+
+		// Create post containing term.
+		$post_arr = array(
+				'post_title' 	=> 'This is a test post title',
+				'post_content'	=> $body,
+				'post_type'		=> 'post',
+				'post_status'	=> 'publish',
+		);
+		$post_id = wp_insert_post( $post_arr );
+
+		// Fake going to the post URL.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the relevant globals are set.
+		global $post;
+		setup_postdata( $post );
+
+		// Initialize substitution engine.
+		$engine = new Glossary_Tooltip_Engine;
+
+		$actual = $engine->glossary_auto_link( $post_arr['post_content'] );
+
+		$this->assertEquals( $actual, $body_tooltip_box );
+	}
+
+
+	function testGlossaryAutoLinkLongText() {
+		// Setup original body and expected output.
+		$body = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tempus lorem purus, vitae sollicitudin libero egestas at. Morbi vestibulum mi justo, nec iaculis magna volutpat et. Integer mattis euismod pellentesque. Donec eu mi eu leo lobortis pulvinar. Praesent mattis ac est quis malesuada. Aenean aliquet urna nec justo semper efficitur. Nam convallis lacus eu quam cursus, vel convallis felis rutrum. Pellentesque lacinia elit augue. Suspendisse potenti. Suspendisse in blandit tellus, eget convallis ante. Maecenas hendrerit sit amet augue in semper. Duis ut libero ut ante dapibus accumsan.
+
+Mauris risus elit, viverra sit amet venenatis eu, bibendum a est. In sollicitudin lacus in diam tempor pharetra. Ut porttitor ligula non ipsum ornare vulputate. Sed vehicula ut orci laoreet bibendum. Suspendisse eget rutrum nisl. Fusce placerat eu erat porta posuere. Integer sit amet vehicula ante, eu euismod leo. Fusce vel felis a ipsum vestibulum dapibus a quis felis. Pellentesque pretium diam sit amet dapibus dapibus. Nunc tristique elementum sollicitudin. Sed luctus convallis pretium. Sed volutpat venenatis pharetra.
+
+Suspendisse rhoncus et magna ac cursus. Aenean sit amet mi elementum dui ullamcorper auctor ut id nulla. Proin vestibulum erat et justo pellentesque auctor. Morbi eget justo tortor. In id quam lorem. Proin vitae ligula dapibus, feugiat ligula vitae, vulputate quam. Nullam ipsum erat, scelerisque sit amet tempor at, sagittis nec quam. Nullam consectetur lorem diam, sit amet elementum quam venenatis in. Donec in turpis et mauris semper ornare eget molestie nisl. In vehicula libero eu enim imperdiet semper. Phasellus rutrum lacus urna, ac feugiat nibh mattis sed. Proin in lectus neque. Maecenas dictum tempor tincidunt. Donec leo libero, iaculis non auctor interdum, commodo vitae libero. Curabitur quis mauris magna.
+
+Etiam bibendum mi quis arcu scelerisque, vehicula fringilla odio ornare. Donec imperdiet tincidunt viverra. Nunc molestie metus at accumsan sodales. Curabitur diam lorem, pharetra a purus sit amet, cursus tempor est. Vestibulum dignissim leo orci, id molestie metus sagittis nec. Maecenas ligula mi, bibendum ut velit non, iaculis porttitor dolor. Aliquam congue condimentum ipsum ac auctor. Donec in felis vitae metus vulputate cursus vitae nec lacus. Aliquam luctus diam vel purus malesuada, non suscipit magna fermentum. Fusce libero sem, tempor id cursus sed, vehicula sit amet ligula. Nulla est justo, bibendum in facilisis id, bibendum vel purus. Sed nec fermentum purus. Quisque arcu urna, luctus non interdum id, auctor ut neque. Nunc vel ex feugiat, iaculis nisl vel, bibendum ipsum. Quisque lacinia pretium dapibus.
+
+Aenean ornare enim leo, sit amet mattis magna convallis et. Vivamus lobortis scelerisque orci non dapibus. Sed vel tellus rhoncus, pulvinar risus sit amet, aliquam neque. In finibus sapien dolor, quis gravida turpis porta fringilla. Aenean convallis felis in purus condimentum, ut rhoncus ipsum imperdiet. Fusce commodo ante dapibus, porttitor nulla ac, aliquet elit. Nunc et magna lacinia, luctus diam eu, congue eros. Duis volutpat justo in metus congue, non pretium leo fermentum. Nam condimentum gravida aliquam. Curabitur vel lectus posuere, elementum purus non, commodo augue. Maecenas facilisis commodo risus a finibus. Sed rhoncus ligula nec nisi imperdiet, ac accumsan lacus ultricies. Morbi auctor dolor mi, ut tempor justo blandit et. Integer nibh dui, egestas et sagittis ac, vestibulum quis tellus. Vivamus sit amet orci turpis.';
+
+		$body_tooltip_box = 'Lorem <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> dolor sit amet, consectetur adipiscing elit. Phasellus tempus lorem purus, vitae sollicitudin libero egestas at. Morbi vestibulum mi justo, nec iaculis magna volutpat et. Integer mattis euismod pellentesque. Donec eu mi eu leo lobortis pulvinar. Praesent mattis ac est quis malesuada. Aenean aliquet urna nec justo semper efficitur. Nam convallis lacus eu quam cursus, vel convallis felis rutrum. Pellentesque lacinia elit augue. Suspendisse potenti. Suspendisse in blandit tellus, eget convallis ante. Maecenas hendrerit sit amet augue in semper. Duis ut libero ut ante dapibus accumsan.
+
+Mauris risus elit, viverra sit amet venenatis eu, bibendum a est. In sollicitudin lacus in diam tempor pharetra. Ut porttitor ligula non <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> ornare vulputate. Sed vehicula ut orci laoreet bibendum. Suspendisse eget rutrum nisl. Fusce placerat eu erat porta posuere. Integer sit amet vehicula ante, eu euismod leo. Fusce vel felis a <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> vestibulum dapibus a quis felis. Pellentesque pretium diam sit amet dapibus dapibus. Nunc tristique elementum sollicitudin. Sed luctus convallis pretium. Sed volutpat venenatis pharetra.
+
+Suspendisse rhoncus et magna ac cursus. Aenean sit amet mi elementum dui ullamcorper auctor ut id nulla. Proin vestibulum erat et justo pellentesque auctor. Morbi eget justo tortor. In id quam lorem. Proin vitae ligula dapibus, feugiat ligula vitae, vulputate quam. Nullam <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> erat, scelerisque sit amet tempor at, sagittis nec quam. Nullam consectetur lorem diam, sit amet elementum quam venenatis in. Donec in turpis et mauris semper ornare eget molestie nisl. In vehicula libero eu enim imperdiet semper. Phasellus rutrum lacus urna, ac feugiat nibh mattis sed. Proin in lectus neque. Maecenas dictum tempor tincidunt. Donec leo libero, iaculis non auctor interdum, commodo vitae libero. Curabitur quis mauris magna.
+
+Etiam bibendum mi quis arcu scelerisque, vehicula fringilla odio ornare. Donec imperdiet tincidunt viverra. Nunc molestie metus at accumsan sodales. Curabitur diam lorem, pharetra a purus sit amet, cursus tempor est. Vestibulum dignissim leo orci, id molestie metus sagittis nec. Maecenas ligula mi, bibendum ut velit non, iaculis porttitor dolor. Aliquam congue condimentum <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> ac auctor. Donec in felis vitae metus vulputate cursus vitae nec lacus. Aliquam luctus diam vel purus malesuada, non suscipit magna fermentum. Fusce libero sem, tempor id cursus sed, vehicula sit amet ligula. Nulla est justo, bibendum in facilisis id, bibendum vel purus. Sed nec fermentum purus. Quisque arcu urna, luctus non interdum id, auctor ut neque. Nunc vel ex feugiat, iaculis nisl vel, bibendum <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span>. Quisque lacinia pretium dapibus.
+
+Aenean ornare enim leo, sit amet mattis magna convallis et. Vivamus lobortis scelerisque orci non dapibus. Sed vel tellus rhoncus, pulvinar risus sit amet, aliquam neque. In finibus sapien dolor, quis gravida turpis porta fringilla. Aenean convallis felis in purus condimentum, ut rhoncus <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> imperdiet. Fusce commodo ante dapibus, porttitor nulla ac, aliquet elit. Nunc et magna lacinia, luctus diam eu, congue eros. Duis volutpat justo in metus congue, non pretium leo fermentum. Nam condimentum gravida aliquam. Curabitur vel lectus posuere, elementum purus non, commodo augue. Maecenas facilisis commodo risus a finibus. Sed rhoncus ligula nec nisi imperdiet, ac accumsan lacus ultricies. Morbi auctor dolor mi, ut tempor justo blandit et. Integer nibh dui, egestas et sagittis ac, vestibulum quis tellus. Vivamus sit amet orci turpis.';
+
+		// Create glossary term.
+		$glossary_post_arr = array(
+				'post_title' 	=> 'Ipsum',
+				'post_content'	=> 'Themself',
+				'post_type'		=> 'glossary',
+				'post_status'	=> 'publish',
+		);
+		$glossary_post_id = wp_insert_post( $glossary_post_arr );
+		add_post_meta( $glossary_post_id, 'glossary_link_type', 'internal' );
+
+		// Create post containing term.
+		$post_arr = array(
+				'post_title' 	=> 'This is a test post title',
+				'post_content'	=> $body,
+				'post_type'		=> 'post',
+				'post_status'	=> 'publish',
+		);
+		$post_id = wp_insert_post( $post_arr );
+
+		// Fake going to the post URL.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the relevant globals are set.
+		global $post;
+		setup_postdata( $post );
+
+		// Initialize substitution engine.
+		$engine = new Glossary_Tooltip_Engine;
+
+		$actual = $engine->glossary_auto_link( $post_arr['post_content'] );
+
+		$this->assertEquals( $actual, $body_tooltip_box );
+	}
+}
+


### PR DESCRIPTION
Currently, the `Glossary_Tooltip_Engine` class is not saved anywhere when created. This is problematic if a theme or plugin wants to remove, add, or change any action of filter hooks within that class.

A great breakdown on why this is problematic [exists on Stack Exchange](http://wordpress.stackexchange.com/a/36110).

**Example:** I want to run a custom `WP_Query` for listing user bios on a page. Pages support auto-linking but profiles do not. The profile bio content would still be scanned for terms and linked. Some variation of the following snippet should work.

```remove_filter( 'the_content', array( $glossary_tooltip_engine, 'glossary_auto_link' ) );```

This pull request fixes this issue by implementing the Singleton pattern within the `Glossary_Tooltip_Engine` and `Glossary_a2z_Archive` classes. I saw this pattern used elsewhere in the plugin, so used it over assigning the class to a variable on instantiation for consistency.

**Note:** because of how our fork is setup, the unit tests added in @jdub233's [pull request](https://github.com/CodeAtCode/Glossary/pull/62) are also included in this pull. But if you merge his pull in first, this will more accurately reflect the changes made.