### PR TITLE
Per post override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+
+php:
+    - 5.5
+    - 5.6
+    - 7.0
+
+env:
+    - WP_VERSION=4.6 WP_MULTISITE=0
+    - WP_VERSION=4.6 WP_MULTISITE=1
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=1
+
+matrix:
+    include:
+        - php: 5.3
+          env: WP_VERSION=4.1.11 WP_MULTISITE=1
+
+
+before_script:
+    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+
+script: phpunit
+
+

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	cd $WP_TESTS_DIR
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -238,7 +238,7 @@ class Glossary {
 	 * @param WP_Post $post WP_Post object.
 	 */
 	function save_post( $post_id, $post ) {
-		if ( ! in_array( $post->post_type, $this->settings['posttypes'], true ) ) {
+		if ( ! in_array( $post->post_type, (array) $this->settings['posttypes'], true ) ) {
 			return;
 		}
 

--- a/public/class-glossary.php
+++ b/public/class-glossary.php
@@ -92,6 +92,9 @@ class Glossary {
     }
 
     add_filter( 'glossary-themes-url', array( $this, 'add_glossary_url' ) );
+
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
   }
 
   /**
@@ -169,7 +172,7 @@ class Glossary {
 
   /**
    * Add the path to the themes
-   * 
+   *
    * @param array $themes
    * @return array
    */
@@ -182,7 +185,7 @@ class Glossary {
 
   /**
    * Hide the taxonomy on the frontend
-   * 
+   *
    * @param object $query
    * @return object
    */
@@ -196,4 +199,67 @@ class Glossary {
     }
   }
 
+	/**
+	 * Add action hook for Glossary disable checkbox field on supported post types.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	function add_meta_boxes( $post_type ) {
+  		if ( ! in_array( $post_type, $this->settings['posttypes'], true ) ) {
+  			return;
+		}
+
+		add_action( 'post_submitbox_misc_actions', array( $this, 'post_submitbox_misc_actions' ) );
+	}
+
+	/**
+	 * Add a checkbox for disabling Glossary term linking on a page.
+	 */
+	function post_submitbox_misc_actions() {
+		$screen = get_current_screen();
+		$post_id = 0;
+
+		if ( 'add' !== $screen->action ) {
+			$post_id = (int) wp_unslash( $_GET['post'] );
+		}
+
+		?>
+		<div class="misc-pub-section glossary-disable">
+			<?php wp_nonce_field( '_glossary_exclude_nonce', '_glossary_exclude_noncename' ); ?>
+			<span><?php _e( 'Disable Glossary linking' ); ?>:</span>&nbsp;<input type="checkbox" name="_glossary_disable" id="_glossary_disable" <?php checked( (bool) get_post_meta( $post_id, '_glossary_disable', true ) ); ?> />
+		</div>
+		<?php
+	}
+
+	/**
+	 * Save the Glossary disable post meta for supported post types.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param WP_Post $post WP_Post object.
+	 */
+	function save_post( $post_id, $post ) {
+		if ( ! in_array( $post->post_type, $this->settings['posttypes'], true ) ) {
+			return;
+		}
+
+		//Skip revisions and autosaves
+		if ( wp_is_post_revision( $post_id ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
+			return;
+		}
+
+		//Users should have the ability to edit.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['_glossary_exclude_noncename'] ) && wp_verify_nonce( $_POST['_glossary_exclude_noncename'], '_glossary_exclude_nonce' ) ) {
+			$disable_glossary = (bool) $_POST['_glossary_disable'];
+
+			if ( $disable_glossary ) {
+				update_post_meta( $post_id, '_glossary_disable', 1 );
+			} else {
+				delete_post_meta( $post_id, '_glossary_disable' );
+			}
+		}
+	}
 }

--- a/public/includes/Glossary_Tooltip_Engine.php
+++ b/public/includes/Glossary_Tooltip_Engine.php
@@ -24,15 +24,23 @@ class Glossary_Tooltip_Engine {
     add_action( 'genesis_entry_content', array( $this, 'genesis_content' ), 9 );
   }
 
-  /**
-   *
-   * The magic function that add the glossary terms to your content
-   *
-   * @global object $post
-   * @param string $text
-   * @return string
-   */
-  public function glossary_auto_link( $text ) {
+	/**
+	 *
+	 * The magic function that add the glossary terms to your content
+	 *
+	 * @global object $post
+	 * @param string $text
+	 * @return string
+	 */
+	public function glossary_auto_link( $text ) {
+		$queried_object = get_queried_object();
+
+		if ( $this->g_is_singular() && is_a( $queried_object, 'WP_Post' ) ) {
+			if ( get_post_meta( $queried_object->ID, '_glossary_disable', true ) ) {
+				return $text;
+			}
+		}
+
     if (
 		$this->g_is_singular() ||
 		$this->g_is_home() ||

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+	require dirname( __FILE__ ) . '/../glossary.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';
+

--- a/tests/test-glossary.php
+++ b/tests/test-glossary.php
@@ -1,0 +1,120 @@
+<?php
+
+class GlossaryTest extends WP_UnitTestCase {
+
+	public $plugin;
+
+	function setUp() {
+
+		parent::setUp();
+
+		// Setup plugin options so that tooltips are enabled.
+		$option_values = array(
+			'posttypes'		=> array( 'post', 'page' ),
+			'tooltip_style'	=> 'box',
+			'excerpt_limit'	=> '60',
+			'slug'			=> 'glossary',
+			'slug-cat'		=> 'glossary-cat',
+			'tooltip'		=> 'on',
+		);
+		add_option( 'glossary-settings', $option_values );
+	}
+
+
+	function testGlossaryAutoLink() {
+		// Setup original body and expected output.
+		$body = 'Post content contains the word philosophy which should have a definition.';
+		$body_tooltip_box = 'Post content contains the word <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=philosophy">philosophy</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">From the latin for love of wisdom.</span></span></span> which should have a definition.';
+
+		// Create glossary term.
+		$glossary_post_arr = array(
+				'post_title' 	=> 'Philosophy',
+				'post_content'	=> 'From the latin for love of wisdom.',
+				'post_type'		=> 'glossary',
+				'post_status'	=> 'publish',
+		);
+		$glossary_post_id = wp_insert_post( $glossary_post_arr );
+		add_post_meta( $glossary_post_id, 'glossary_link_type', 'internal' );
+
+		// Create post containing term.
+		$post_arr = array(
+				'post_title' 	=> 'This is a test post title',
+				'post_content'	=> $body,
+				'post_type'		=> 'post',
+				'post_status'	=> 'publish',
+		);
+		$post_id = wp_insert_post( $post_arr );
+
+		// Fake going to the post URL.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the relevant globals are set.
+		global $post;
+		setup_postdata( $post );
+
+		// Initialize substitution engine.
+		$engine = new Glossary_Tooltip_Engine;
+
+		$actual = $engine->glossary_auto_link( $post_arr['post_content'] );
+
+		$this->assertEquals( $actual, $body_tooltip_box );
+	}
+
+
+	function testGlossaryAutoLinkLongText() {
+		// Setup original body and expected output.
+		$body = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tempus lorem purus, vitae sollicitudin libero egestas at. Morbi vestibulum mi justo, nec iaculis magna volutpat et. Integer mattis euismod pellentesque. Donec eu mi eu leo lobortis pulvinar. Praesent mattis ac est quis malesuada. Aenean aliquet urna nec justo semper efficitur. Nam convallis lacus eu quam cursus, vel convallis felis rutrum. Pellentesque lacinia elit augue. Suspendisse potenti. Suspendisse in blandit tellus, eget convallis ante. Maecenas hendrerit sit amet augue in semper. Duis ut libero ut ante dapibus accumsan.
+
+Mauris risus elit, viverra sit amet venenatis eu, bibendum a est. In sollicitudin lacus in diam tempor pharetra. Ut porttitor ligula non ipsum ornare vulputate. Sed vehicula ut orci laoreet bibendum. Suspendisse eget rutrum nisl. Fusce placerat eu erat porta posuere. Integer sit amet vehicula ante, eu euismod leo. Fusce vel felis a ipsum vestibulum dapibus a quis felis. Pellentesque pretium diam sit amet dapibus dapibus. Nunc tristique elementum sollicitudin. Sed luctus convallis pretium. Sed volutpat venenatis pharetra.
+
+Suspendisse rhoncus et magna ac cursus. Aenean sit amet mi elementum dui ullamcorper auctor ut id nulla. Proin vestibulum erat et justo pellentesque auctor. Morbi eget justo tortor. In id quam lorem. Proin vitae ligula dapibus, feugiat ligula vitae, vulputate quam. Nullam ipsum erat, scelerisque sit amet tempor at, sagittis nec quam. Nullam consectetur lorem diam, sit amet elementum quam venenatis in. Donec in turpis et mauris semper ornare eget molestie nisl. In vehicula libero eu enim imperdiet semper. Phasellus rutrum lacus urna, ac feugiat nibh mattis sed. Proin in lectus neque. Maecenas dictum tempor tincidunt. Donec leo libero, iaculis non auctor interdum, commodo vitae libero. Curabitur quis mauris magna.
+
+Etiam bibendum mi quis arcu scelerisque, vehicula fringilla odio ornare. Donec imperdiet tincidunt viverra. Nunc molestie metus at accumsan sodales. Curabitur diam lorem, pharetra a purus sit amet, cursus tempor est. Vestibulum dignissim leo orci, id molestie metus sagittis nec. Maecenas ligula mi, bibendum ut velit non, iaculis porttitor dolor. Aliquam congue condimentum ipsum ac auctor. Donec in felis vitae metus vulputate cursus vitae nec lacus. Aliquam luctus diam vel purus malesuada, non suscipit magna fermentum. Fusce libero sem, tempor id cursus sed, vehicula sit amet ligula. Nulla est justo, bibendum in facilisis id, bibendum vel purus. Sed nec fermentum purus. Quisque arcu urna, luctus non interdum id, auctor ut neque. Nunc vel ex feugiat, iaculis nisl vel, bibendum ipsum. Quisque lacinia pretium dapibus.
+
+Aenean ornare enim leo, sit amet mattis magna convallis et. Vivamus lobortis scelerisque orci non dapibus. Sed vel tellus rhoncus, pulvinar risus sit amet, aliquam neque. In finibus sapien dolor, quis gravida turpis porta fringilla. Aenean convallis felis in purus condimentum, ut rhoncus ipsum imperdiet. Fusce commodo ante dapibus, porttitor nulla ac, aliquet elit. Nunc et magna lacinia, luctus diam eu, congue eros. Duis volutpat justo in metus congue, non pretium leo fermentum. Nam condimentum gravida aliquam. Curabitur vel lectus posuere, elementum purus non, commodo augue. Maecenas facilisis commodo risus a finibus. Sed rhoncus ligula nec nisi imperdiet, ac accumsan lacus ultricies. Morbi auctor dolor mi, ut tempor justo blandit et. Integer nibh dui, egestas et sagittis ac, vestibulum quis tellus. Vivamus sit amet orci turpis.';
+
+		$body_tooltip_box = 'Lorem <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> dolor sit amet, consectetur adipiscing elit. Phasellus tempus lorem purus, vitae sollicitudin libero egestas at. Morbi vestibulum mi justo, nec iaculis magna volutpat et. Integer mattis euismod pellentesque. Donec eu mi eu leo lobortis pulvinar. Praesent mattis ac est quis malesuada. Aenean aliquet urna nec justo semper efficitur. Nam convallis lacus eu quam cursus, vel convallis felis rutrum. Pellentesque lacinia elit augue. Suspendisse potenti. Suspendisse in blandit tellus, eget convallis ante. Maecenas hendrerit sit amet augue in semper. Duis ut libero ut ante dapibus accumsan.
+
+Mauris risus elit, viverra sit amet venenatis eu, bibendum a est. In sollicitudin lacus in diam tempor pharetra. Ut porttitor ligula non <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> ornare vulputate. Sed vehicula ut orci laoreet bibendum. Suspendisse eget rutrum nisl. Fusce placerat eu erat porta posuere. Integer sit amet vehicula ante, eu euismod leo. Fusce vel felis a <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> vestibulum dapibus a quis felis. Pellentesque pretium diam sit amet dapibus dapibus. Nunc tristique elementum sollicitudin. Sed luctus convallis pretium. Sed volutpat venenatis pharetra.
+
+Suspendisse rhoncus et magna ac cursus. Aenean sit amet mi elementum dui ullamcorper auctor ut id nulla. Proin vestibulum erat et justo pellentesque auctor. Morbi eget justo tortor. In id quam lorem. Proin vitae ligula dapibus, feugiat ligula vitae, vulputate quam. Nullam <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> erat, scelerisque sit amet tempor at, sagittis nec quam. Nullam consectetur lorem diam, sit amet elementum quam venenatis in. Donec in turpis et mauris semper ornare eget molestie nisl. In vehicula libero eu enim imperdiet semper. Phasellus rutrum lacus urna, ac feugiat nibh mattis sed. Proin in lectus neque. Maecenas dictum tempor tincidunt. Donec leo libero, iaculis non auctor interdum, commodo vitae libero. Curabitur quis mauris magna.
+
+Etiam bibendum mi quis arcu scelerisque, vehicula fringilla odio ornare. Donec imperdiet tincidunt viverra. Nunc molestie metus at accumsan sodales. Curabitur diam lorem, pharetra a purus sit amet, cursus tempor est. Vestibulum dignissim leo orci, id molestie metus sagittis nec. Maecenas ligula mi, bibendum ut velit non, iaculis porttitor dolor. Aliquam congue condimentum <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> ac auctor. Donec in felis vitae metus vulputate cursus vitae nec lacus. Aliquam luctus diam vel purus malesuada, non suscipit magna fermentum. Fusce libero sem, tempor id cursus sed, vehicula sit amet ligula. Nulla est justo, bibendum in facilisis id, bibendum vel purus. Sed nec fermentum purus. Quisque arcu urna, luctus non interdum id, auctor ut neque. Nunc vel ex feugiat, iaculis nisl vel, bibendum <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span>. Quisque lacinia pretium dapibus.
+
+Aenean ornare enim leo, sit amet mattis magna convallis et. Vivamus lobortis scelerisque orci non dapibus. Sed vel tellus rhoncus, pulvinar risus sit amet, aliquam neque. In finibus sapien dolor, quis gravida turpis porta fringilla. Aenean convallis felis in purus condimentum, ut rhoncus <span class="glossary-tooltip"><span class="glossary-tooltip-item"><a href="http://example.org/?glossary=ipsum">ipsum</a></span><span class="glossary-tooltip-content clearfix"><span class="glossary-tooltip-text">Themself</span></span></span> imperdiet. Fusce commodo ante dapibus, porttitor nulla ac, aliquet elit. Nunc et magna lacinia, luctus diam eu, congue eros. Duis volutpat justo in metus congue, non pretium leo fermentum. Nam condimentum gravida aliquam. Curabitur vel lectus posuere, elementum purus non, commodo augue. Maecenas facilisis commodo risus a finibus. Sed rhoncus ligula nec nisi imperdiet, ac accumsan lacus ultricies. Morbi auctor dolor mi, ut tempor justo blandit et. Integer nibh dui, egestas et sagittis ac, vestibulum quis tellus. Vivamus sit amet orci turpis.';
+
+		// Create glossary term.
+		$glossary_post_arr = array(
+				'post_title' 	=> 'Ipsum',
+				'post_content'	=> 'Themself',
+				'post_type'		=> 'glossary',
+				'post_status'	=> 'publish',
+		);
+		$glossary_post_id = wp_insert_post( $glossary_post_arr );
+		add_post_meta( $glossary_post_id, 'glossary_link_type', 'internal' );
+
+		// Create post containing term.
+		$post_arr = array(
+				'post_title' 	=> 'This is a test post title',
+				'post_content'	=> $body,
+				'post_type'		=> 'post',
+				'post_status'	=> 'publish',
+		);
+		$post_id = wp_insert_post( $post_arr );
+
+		// Fake going to the post URL.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Make sure the relevant globals are set.
+		global $post;
+		setup_postdata( $post );
+
+		// Initialize substitution engine.
+		$engine = new Glossary_Tooltip_Engine;
+
+		$actual = $engine->glossary_auto_link( $post_arr['post_content'] );
+
+		$this->assertEquals( $actual, $body_tooltip_box );
+	}
+}
+


### PR DESCRIPTION
Currently, there is no fine grained control over which posts receive Glossary auto-linking: it is all or nothing.

This pull request adds a checkbox above the publish button to disable term auto-linking everywhere on that post.

We have a use case where it is not desired for the home page and a few other pages to be riddled with definition links. This helps solve that.

It might be worth opening an issue though to discuss how post types are linked further.

**Note:** because of how our fork is setup, the unit tests added in @jdub233's pull request are also included in this pull. But if you merge his pull in first, this will more accurately reflect the changes made.
